### PR TITLE
Fix `'float' object cannot be interpreted as an integer`

### DIFF
--- a/vm-paging/paging-linear-translate.py
+++ b/vm-paging/paging-linear-translate.py
@@ -87,13 +87,13 @@ mustbemultipleof(asize, pagesize, 'address space must be a multiple of the pages
 mustbemultipleof(psize, pagesize, 'physical memory must be a multiple of the pagesize')
 
 # print some useful info, like the darn page table 
-pages = psize / pagesize;
+pages = psize // pagesize
 import array
 used = array.array('i')
 pt   = array.array('i')
 for i in range(0,pages):
     used.insert(i,0)
-vpages = asize / pagesize
+vpages = asize // pagesize
 
 # now, assign some pages of the VA
 vabits   = int(math.log(float(asize))/math.log(2.0))

--- a/vm-smalltables/paging-multilevel-translate.py
+++ b/vm-smalltables/paging-multilevel-translate.py
@@ -43,7 +43,7 @@ class OS:
         # os tracks
         self.usedPages      = []
         self.usedPagesCount = 0
-        self.maxPageCount   = self.physMem / self.pageSize
+        self.maxPageCount   = self.physMem // self.pageSize
 
         # no pages used (yet)
         for i in range(0, self.maxPageCount):
@@ -186,7 +186,7 @@ class OS:
         print('')
 
     def memoryDump(self):
-        for i in range(0, self.physMem / self.pageSize):
+        for i in range(0, self.maxPageCount):
             print('page %3d:' %  i, end='')
             for j in range(0, self.pageSize):
                 print('%02x' % self.memory[(i * self.pageSize) + j], end='')


### PR DESCRIPTION
The semantic of `/` is changed since Python 3. This PR changes `/` (floating-point division as in Python 3) to `//` (integer division) so that `range` won't complain about the typing issue. 