### PR TITLE
Fixed key error issue in file-disks/disk.py

### DIFF
--- a/file-disks/disk.py
+++ b/file-disks/disk.py
@@ -313,10 +313,16 @@ class Disk:
             self.blockInfoList.append((track, angle + (angleOffset * skew), block))
         self.tracksBeginEnd[track] = (pblock, block)
         self.maxBlock              = pblock
+        
         # print 'MAX BLOCK:', self.maxBlock
 
         # adjust angle to starting position relative 
+        self.maxBlockToAngleMap = max(self.blockToAngleMap)
         for i in self.blockToAngleMap:
+            for block in self.addr.split(","):
+                if int(block) > self.maxBlockToAngleMap:
+                    print("Error: The requested block address %s is greater than the maximum block %d available"%(block,self.maxBlockToAngleMap))
+                    sys.exit(1)
             self.blockToAngleMap[i] = (self.blockToAngleMap[i] + 180) % 360
 
         # print 'btoa map', self.blockToAngleMap
@@ -338,7 +344,7 @@ class Disk:
             for i in range(numRequests):
                 tmpList.append(int(random.random() * maxRequest) + minRequest)
             return tmpList
-        else:
+        else:   
             return addr.split(',')
 
     #


### PR DESCRIPTION
If the requested list of block addresses contains a block address greater than the computed block of addresses it throws a key error while seeking and the seeking action wouldn’t stop. Fixed this issue in file-disks/disk.py by exiting the program if the requested block is less than the maximum block allowed in InitBlockLayout.
ex: 
./disk.py -a 10,20,40 -G.
(without the changes the above command would throw key error 40)
After the changes the program would exit with the following message 
**Error: The requested block address 40 is greater than the maximum block 35 available.**