### PR TITLE
reset boosted job's left ticks to top queue's quantum

### DIFF
--- a/cpu-sched-mlfq/mlfq.py
+++ b/cpu-sched-mlfq/mlfq.py
@@ -246,7 +246,7 @@ while finishedJobs < totalJobs:
                 if job[j]['timeLeft'] > 0:
                     # print('-> FinalBoost %d (timeLeft %d)' % (j, job[j]['timeLeft']))
                     job[j]['currPri']   = hiQueue
-                    job[j]['ticksLeft'] = allotment[hiQueue]
+                    job[j]['ticksLeft'] = quantum[hiQueue]
             # print('BOOST END: QUEUES look like:', queue)
 
     # check for any I/Os done


### PR DESCRIPTION
It should use `quantum` instead of `allotment`.