### PR TITLE
Fix the paging-multilevel-translate.py to work with Python 3

### DIFF
--- a/vm-smalltables/paging-multilevel-translate.py
+++ b/vm-smalltables/paging-multilevel-translate.py
@@ -51,7 +51,7 @@ class OS:
         # os tracks
         self.usedPages      = []
         self.usedPagesCount = 0
-        self.maxPageCount   = self.physMem / self.pageSize
+        self.maxPageCount   = self.physMem // self.pageSize
 
         # no pages used (yet)
         for i in range(0, self.maxPageCount):
@@ -194,7 +194,7 @@ class OS:
         print('')
 
     def memoryDump(self):
-        for i in range(0, self.physMem / self.pageSize):
+        for i in range(0, self.physMem // self.pageSize):
             print('page %3d:' %  i, end='')
             for j in range(0, self.pageSize):
                 print('%02x' % self.memory[(i * self.pageSize) + j], end='')


### PR DESCRIPTION
When running this script with python 3, we get the following error:

> ❯ python3 paging-multilevel-translate.py
> ARG seed 0
> ARG allocated 64
> ARG num 10
>
>Traceback (most recent call last):
>  File "paging-multilevel-translate.py", line 241, in <module>
>    os = OS()
>  File "paging-multilevel-translate.py", line 57, in __init__
>    for i in range(0, self.maxPageCount):
>TypeError: 'float' object cannot be interpreted as an integer


This is due to a breaking change in Python 3, where the division operator represents *true division*, producing a floating point result. Whereas in Python 2, it performs *classic division* that rounds the result down toward negative infinity (also known as taking the floor).

This PR changes the operator to use `//`, which according to the docs:

https://www.python.org/dev/peps/pep-0238/

> The // operator will be available to request floor division unambiguously.

This should make the script Python 2 and 3 compatible.
