### PR TITLE
Ch. 45 checksum.py - changes output format to columns; fixes the readme

### DIFF
--- a/file-integrity/README.md
+++ b/file-integrity/README.md
@@ -45,11 +45,14 @@ prompt> ./checksum.py -s 1
 
 OPTIONS seed 1
 OPTIONS data_size 4
-OPTIONS data
+OPTIONS data 
 
-Decimal:           34        216        195         65
-Hex:             0x22       0xd8       0xc3       0x41
-Bin:       0b00100010 0b11011000 0b11000011 0b01000001
+  Decimal:     Hex:     Bin:    
+        34     0x22     0b00100010
+       216     0xd8     0b11011000
+       195     0xc3     0b11000011
+        65     0x41     0b01000001
+
 
 Add:      ?
 Xor:      ?
@@ -61,21 +64,39 @@ prompt>
 You can specify a different length for the random data:
 
 ```sh
-prompt> ./checksum.py -D 2
+prompt> ./checksum.py -d 2
 
-...
+OPTIONS seed 0
+OPTIONS data_size 2
+OPTIONS data 
+
+  Decimal:     Hex:     Bin:    
+       216     0xd8     0b11011000
+       194     0xc2     0b11000010
+
+
+Add:      ?
+Xor:      ?
+Fletcher: ?
+
+prompt> 
+```
 
 You can also specify your own data string:
 
+```sh
 prompt> ./checksum.py -D 1,2,3,4
 
 OPTIONS seed 0
 OPTIONS data_size 4
 OPTIONS data 1,2,3,4
 
-Decimal:            1          2          3          4
-Hex:             0x01       0x02       0x03       0x04
-Bin:       0b00000001 0b00000010 0b00000011 0b00000100
+  Decimal:     Hex:     Bin:    
+         1     0x01     0b00000001
+         2     0x02     0b00000010
+         3     0x03     0b00000011
+         4     0x04     0b00000100
+
 
 Add:      ?
 Xor:      ?
@@ -93,9 +114,12 @@ OPTIONS seed 0
 OPTIONS data_size 4
 OPTIONS data 1,2,3,4
 
-Decimal:            1          2          3          4
-Hex:             0x01       0x02       0x03       0x04
-Bin:       0b00000001 0b00000010 0b00000011 0b00000100
+  Decimal:     Hex:     Bin:    
+         1     0x01     0b00000001
+         2     0x02     0b00000010
+         3     0x03     0b00000011
+         4     0x04     0b00000100
+
 
 Add:             10       (0b00001010)
 Xor:              4       (0b00000100)

--- a/file-integrity/checksum.py
+++ b/file-integrity/checksum.py
@@ -35,10 +35,6 @@ parser.add_option('-c', '--compute', help='compute answers for me', action='stor
 
 print('')
 print('OPTIONS seed', options.seed)
-print('OPTIONS data_size', options.data_size)
-print('OPTIONS data', options.data)
-print('')
-
 random_seed(options.seed)
 
 values = []
@@ -46,9 +42,14 @@ if options.data != '':
     tmp = options.data.split(',')
     for t in tmp:
         values.append(int(t))
+    options.data_size=len(values)
 else:
     for t in range(int(options.data_size)):
         values.append(int(random.random() * 256))
+
+print('OPTIONS data_size', options.data_size)
+print('OPTIONS data', options.data)
+print('')
 
 
 add = 0
@@ -61,20 +62,18 @@ for value in values:
     fletcher_a = (fletcher_a + value) % 255
     fletcher_b = (fletcher_b + fletcher_a) % 255
 
-print('Decimal:  ', end=' ')
+# --------------------------------------------
+
+print('  Decimal:    ', end=' ')
+print('Hex:    ', end=' ')
+print('Bin:    ', end='\n')
 for word in values:
     print('%10s' % str(word), end=' ')
+    print('   ', print_hex(word), end=' ')
+    print('   ', print_bin(word), end='\n')
 print('')
 
-print('Hex:      ', end=' ')
-for word in values:
-    print('     ', print_hex(word), end=' ')
-print('')
-
-print('Bin:      ', end=' ')
-for word in values:
-    print(print_bin(word), end=' ')
-print('')
+# --------------------------------------------
 
 print('')
 if options.solve:


### PR DESCRIPTION
in the README file:
    fixes an error
        -D 2 should have been a -d 2 in an example
    changes the examples to use the new output format

in checksum.py
    reorders some code so that the data_size parameter is correct when the user uses -D to supply custom data

    rearranges some code so that the printout of data values is in columns (rather than rows):
            for easier summing, xor-ing
            for cleaner display for larger values of -d  (avoids line wrapping)

Here is the new order; much easier to do checksums on a column of data.
  Decimal:     Hex:     Bin:
       216     0xd8     0b11011000
       194     0xc2     0b11000010
       107     0x6b     0b01101011
         66     0x42     0b01000010
