### PR TITLE
Fix stdout strings by adding spaces

### DIFF
--- a/cpu-intro/process-run.py
+++ b/cpu-intro/process-run.py
@@ -314,14 +314,14 @@ if options.solve == False:
     print('Important behaviors:')
     print('  System will switch when', end='')
     if options.process_switch_behavior == SCHED_SWITCH_ON_IO:
-        print('the current process is FINISHED or ISSUES AN IO')
+        print(' the current process is FINISHED or ISSUES AN IO')
     else:
-        print('the current process is FINISHED')
+        print(' the current process is FINISHED')
     print('  After IOs, the process issuing the IO will', end='')
     if options.io_done_behavior == IO_RUN_IMMEDIATE:
-        print('run IMMEDIATELY')
+        print(' run IMMEDIATELY')
     else:
-        print('run LATER (when it is its turn)')
+        print(' run LATER (when it is its turn)')
     print('')
     exit(0)
 


### PR DESCRIPTION
Simply to unglue some of the words caught together without spacing.

For example, when running the 'process-run.py' with --switch=SWITCH_ON_IO and --iodone=IO_RUN_LATER, the output would have been as followed:

```sh
...

Important behaviors:
  System will switch whenthe current process is FINISHED or ISSUES AN IO
  After IOs, the process issuing the IO willrun LATER (when it is its turn)
```