### PR TITLE
Fix bug when checking seg fit in the phys memory

### DIFF
--- a/threads-intro/README.md
+++ b/threads-intro/README.md
@@ -166,8 +166,8 @@ flag sets the `%dx` register to the value 3 to start with.
 
 As you can see from the trace, the `sub` instruction slowly lowers the value
 of %dx. The first few times `test` is called, only the ">=", ">", and "!="
-conditions get set. However, the last `test` in the trace finds %dx and 0 to
-be equal, and thus the subsequent jump does NOT take place, and the program
+conditions get set. However, the last `test` in the trace finds %dx less than
+0, and thus the subsequent jump does NOT take place, and the program
 finally halts.
 
 Now, finally, we get to a more interesting case, i.e., a race condition with

--- a/vm-segmentation/segmentation.py
+++ b/vm-segmentation/segmentation.py
@@ -106,9 +106,9 @@ if base1 == -1:
 else:
     base1 = base1 - len1
 
-abort_if(psize < base0 + len0 - 1, 'seg0 is not in physical memory')
-abort_if(psize < base1, 'seg1 is not in physical memory')
-    
+abort_if((0 > base0) or (psize < base0 + len0), 'seg0 is not in physical memory')
+abort_if((0 > base1) or (psize < base1 + len1), 'seg1 is not in physical memory')
+
 abort_if(len0 > asize/2.0, 'length0 register is too large for this address space')
 abort_if(len1 > asize/2.0, 'length1 register is too large for this address space')
 


### PR DESCRIPTION
segment may out of the phys memory

for example:
```
> ./segmentation.py -a 16 -p 128 -A 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 --b0 127 --l0 2 --b1 0 --l1 2 -c
ARG seed 0
ARG address space size 16
ARG phys mem size 128

Segment register information:

  Segment 0 base  (grows positive) : 0x0000007f (decimal 127)
  Segment 0 limit                  : 2

  Segment 1 base  (grows negative) : 0x00000000 (decimal 0)
  Segment 1 limit                  : 2

Virtual Address Trace
  VA  0: 0x00000000 (decimal:    0) --> VALID in SEG0: 0x0000007f (decimal:  127)
  VA  1: 0x00000001 (decimal:    1) --> VALID in SEG0: 0x00000080 (decimal:  128)
  VA  2: 0x00000002 (decimal:    2) --> SEGMENTATION VIOLATION (SEG0)
  VA  3: 0x00000003 (decimal:    3) --> SEGMENTATION VIOLATION (SEG0)
  VA  4: 0x00000004 (decimal:    4) --> SEGMENTATION VIOLATION (SEG0)
  VA  5: 0x00000005 (decimal:    5) --> SEGMENTATION VIOLATION (SEG0)
  VA  6: 0x00000006 (decimal:    6) --> SEGMENTATION VIOLATION (SEG0)
  VA  7: 0x00000007 (decimal:    7) --> SEGMENTATION VIOLATION (SEG0)
  VA  8: 0x00000008 (decimal:    8) --> SEGMENTATION VIOLATION (SEG1)
  VA  9: 0x00000009 (decimal:    9) --> SEGMENTATION VIOLATION (SEG1)
  VA 10: 0x0000000a (decimal:   10) --> SEGMENTATION VIOLATION (SEG1)
  VA 11: 0x0000000b (decimal:   11) --> SEGMENTATION VIOLATION (SEG1)
  VA 12: 0x0000000c (decimal:   12) --> SEGMENTATION VIOLATION (SEG1)
  VA 13: 0x0000000d (decimal:   13) --> SEGMENTATION VIOLATION (SEG1)
  VA 14: 0x0000000e (decimal:   14) --> VALID in SEG1: 0x-0000002 (decimal:   -2)
  VA 15: 0x0000000f (decimal:   15) --> VALID in SEG1: 0x-0000001 (decimal:   -1)

```
VA 1, VA 14 and VA 15 translated to the invalid phys addr (128, -2, -1)

base1 had been modified to point to the lower address before the check