### PR TITLE
README.md error corrected

### DIFF
--- a/cpu-sched-mlfq/README.md
+++ b/cpu-sched-mlfq/README.md
@@ -76,7 +76,7 @@ For each job, three defining characteristics are given:
 
 Job List:
   Job  0: startTime   0 - runTime  84 - ioFreq   7
-  Job  1: startTime   0 - runTime  42 - ioFreq   2
+  Job  1: startTime   0 - runTime  42 - ioFreq   3
   Job  2: startTime   0 - runTime  51 - ioFreq   4
 
 Compute the execution trace for the given workloads.


### PR DESCRIPTION
The default ioFreq for Job 1 should be 3. Otherwise, Job 1 should start an IO request on line 111.