### PR TITLE
Fix bug when checking seg fit or overlap in the phys memory

### DIFF
--- a/vm-segmentation/segmentation.py
+++ b/vm-segmentation/segmentation.py
@@ -106,9 +106,9 @@ if base1 == -1:
 else:
     base1 = base1 - len1
 
-abort_if(psize < base0 + len0 - 1, 'seg0 is not in physical memory')
-abort_if(psize < base1, 'seg1 is not in physical memory')
-    
+abort_if((base0 < 0) or (psize < base0 + len0), 'seg0 is not in physical memory')
+abort_if((base1 < 0) or (psize < base1 + len1), 'seg1 is not in physical memory')
+
 abort_if(len0 > asize/2.0, 'length0 register is too large for this address space')
 abort_if(len1 > asize/2.0, 'length1 register is too large for this address space')
 
@@ -123,7 +123,7 @@ print('')
 
 nbase1 = base1 + len1
 
-abort_if((len0 + base0) > base1 and (base1 > base0), 'segments overlap in physical memory')
+abort_if((len0 + base0) > base1 and (nbase1 > base0), 'segments overlap in physical memory')
 
 addrList = []
 if addresses == '-1':


### PR DESCRIPTION
segments mayoverlap or out of the phys memory

out of phys memory:
```
> ./segmentation.py -a 16 -p 128 -A 1,14,15 --b0 127 --l0 2 --b1 0 --l1 2 -c
ARG seed 0
ARG address space size 16
ARG phys mem size 128

Segment register information:

  Segment 0 base  (grows positive) : 0x0000007f (decimal 127)
  Segment 0 limit                  : 2

  Segment 1 base  (grows negative) : 0x00000000 (decimal 0)
  Segment 1 limit                  : 2

Virtual Address Trace
  VA  0: 0x00000001 (decimal:    1) --> VALID in SEG0: 0x00000080 (decimal:  128)
  VA  1: 0x0000000e (decimal:   14) --> VALID in SEG1: 0x-0000002 (decimal:   -2)
  VA  2: 0x0000000f (decimal:   15) --> VALID in SEG1: 0x-0000001 (decimal:   -1)
```
and overlap:
```
./segmentation.py -a 16 -p 128 -A 1,15 --b0 64 --l0 2 --b1 66 --l1 5 -c
ARG seed 0
ARG address space size 16
ARG phys mem size 128

Segment register information:

  Segment 0 base  (grows positive) : 0x00000040 (decimal 64)
  Segment 0 limit                  : 2

  Segment 1 base  (grows negative) : 0x00000042 (decimal 66)
  Segment 1 limit                  : 5

Virtual Address Trace
  VA  0: 0x00000001 (decimal:    1) --> VALID in SEG0: 0x00000041 (decimal:   65)
  VA  1: 0x0000000f (decimal:   15) --> VALID in SEG1: 0x00000041 (decimal:   65)
```