### PR TITLE
missing pthread_join in main-signal-cv.c

### DIFF
--- a/threads-api/main-signal-cv.c
+++ b/threads-api/main-signal-cv.c
@@ -50,6 +50,7 @@ int main(int argc, char *argv[]) {
     Pthread_create(&p, NULL, worker, NULL);
     signal_wait(&s);
     printf("this should print last\n");
+    Pthread_join(p, NULL);
 
     return 0;
 }


### PR DESCRIPTION
Pthread_join is missing in the `main-signal-cv.c`. 

Without pthread_join I get the following ThreadSanitizer thread leak on MacOS:
```
WARNING: ThreadSanitizer: thread leak (pid=56924)           
  Thread T1 (tid=6869398, finished) created by main thread at:                                                                                                                       
    #0 pthread_create <null>:93329120 (libclang_rt.tsan_osx_dynamic.dylib:arm64+0x9400) (BuildId: 9227ab97c5583bf4bf416813368ede8632000000200000000100000000000b00)                  │
    #1 main main-signal-cv.c:50 (a.out:arm64+0x100003b80) (BuildId: 2984ab0c7605351bb8d28110e3129afd32000000200000000100000000000e00)                                                │                                                                                                                        
```