### PR TITLE
Fixed `x86.py -S` printstats compatibility bugs in both Python 2 AND 3

### DIFF
--- a/threads-intro/x86.py
+++ b/threads-intro/x86.py
@@ -6,19 +6,22 @@ import time
 import random
 from optparse import OptionParser
 
-# to make Python2 and Python3 act the same -- how dumb
 def random_seed(seed):
     try:
+        # Introduced in Python 3.2 to match legacy versions
+        #   https://docs.python.org/3.2/library/random.html#random.seed
         random.seed(seed, version=1)
     except:
-        random.seed(seed)
+        random.seed(seed)  # before Python 3.2 (including Python 2)
     return
 
 def time_clock():
     try:
-        rc = time_clock()
-    except:
+        # Introduced in Python 3.3
+        #   https://docs.python.org/3/library/time.html#time.process_time
         rc = time.process_time()
+    except:
+        rc = time.clock()  # before Python 3.3 (including Python 2)
     return rc
 
 #

--- a/threads-locks/x86.py
+++ b/threads-locks/x86.py
@@ -6,19 +6,22 @@ import time
 import random
 from optparse import OptionParser
 
-# to make Python2 and Python3 act the same -- how dumb
 def random_seed(seed):
     try:
+        # Introduced in Python 3.2 to match legacy versions
+        #   https://docs.python.org/3.2/library/random.html#random.seed
         random.seed(seed, version=1)
     except:
-        random.seed(seed)
+        random.seed(seed)  # before Python 3.2 (including Python 2)
     return
 
 def time_clock():
     try:
-        rc = time_clock()
-    except:
+        # Introduced in Python 3.3
+        #   https://docs.python.org/3/library/time.html#time.process_time
         rc = time.process_time()
+    except:
+        rc = time.clock()  # before Python 3.3 (including Python 2)
     return rc
 
 #


### PR DESCRIPTION
# The Problem

`x86.py -S` errors out in Python 2.7 (which executes under most system defaults for `#! /usr/bin/env python`). I discovered this on a relatively clean build of `macOS Sonoma 14.4` in the `Terminal.app`.

# My Solution

* **fixed _both_ `x86.py` implementations** (tested in both Python 2.7 & Python 3.12)
* included links to relevant version-specific documentation