### PR TITLE
Rename num_active to num_runnable in get_num_runnable() for clarity

### DIFF
--- a/cpu-intro/process-run.py
+++ b/cpu-intro/process-run.py
@@ -153,12 +153,12 @@ class scheduler:
         return num_active
 
     def get_num_runnable(self):
-        num_active = 0
+        num_runnable = 0
         for pid in range(len(self.proc_info)):
             if self.proc_info[pid][PROC_STATE] == STATE_READY or \
                    self.proc_info[pid][PROC_STATE] == STATE_RUNNING:
-                num_active += 1
-        return num_active
+                num_runnable += 1
+        return num_runnable
 
     def get_ios_in_flight(self, current_time):
         num_in_flight = 0


### PR DESCRIPTION
get_num_active() uses variable num_active to track processes that are not finished.
get_ios_in_flight() uses variable num_in_flight to track processes waiting on io return.

get_num_runnable() should use variable num_runnable rather than num_active, to track ready or runnable processes.