### PR TITLE
fix: logical typo in threads-intro/README.md

### DIFF
--- a/threads-intro/README.md
+++ b/threads-intro/README.md
@@ -166,8 +166,7 @@ flag sets the `%dx` register to the value 3 to start with.
 
 As you can see from the trace, the `sub` instruction slowly lowers the value
 of %dx. The first few times `test` is called, only the ">=", ">", and "!="
-conditions get set. However, the last `test` in the trace finds %dx and 0 to
-be equal, and thus the subsequent jump does NOT take place, and the program
+conditions get set. However, the last `test` in the trace finds %dx (-1) to be smaller than 0 (jgte condition not met), and thus the subsequent jump does NOT take place, and the program
 finally halts.
 
 Now, finally, we get to a more interesting case, i.e., a race condition with


### PR DESCRIPTION
Noticed a minor logical typo in threads-intro/README.md regarding the jgte condition. Fixed it with the wordings I though was clear enough for the reader.